### PR TITLE
Fix descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.1
+
+* Fix a bug in the `createCustomCollection` and `createSmartCollection` endpoints that prevented to use them.
+* Update the semantic of the Guzzle service description to more closely reflect the nature of some properties.
+
 # 2.1.0
 
 * Add new `getCommand`, `execute` and `executeAll` methods which proxy to Guzzle client equivalent methods and allow more advanced use cases

--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -364,7 +364,7 @@ return [
                 'image' => [
                     'description' => 'Set the image (either through a base 64 attachment or URL)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'metafields' => [
@@ -440,7 +440,7 @@ return [
                 'image' => [
                     'description' => 'Set the image (either through a base 64 attachment or URL)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'metafields' => [
@@ -516,7 +516,7 @@ return [
                 'image' => [
                     'description' => 'Set the image (either through a base 64 attachment or URL)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'metafields' => [
@@ -598,7 +598,7 @@ return [
                 'image' => [
                     'description' => 'Set the image (either through a base 64 attachment or URL)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'metafields' => [
@@ -944,9 +944,9 @@ return [
             'parameters'       => [
                 'title' => [
                     'description' => 'Custom collection title',
-                    'location'    => 'query',
+                    'location'    => 'json',
                     'type'        => 'string',
-                    'required'    => false
+                    'required'    => true
                 ],
                 'body_html' => [
                     'description' => 'Collection description',
@@ -963,7 +963,7 @@ return [
                 'image' => [
                     'description' => 'Attached image (can accept a "src" or "attachment" sub-parameter)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'collects' => [
@@ -1015,7 +1015,7 @@ return [
                 'image' => [
                     'description' => 'Attached image (can accept a "src" or "attachment" sub-parameter)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'collects' => [
@@ -1448,7 +1448,7 @@ return [
                 'metafield' => [
                     'description' => 'Filter metafields by resource type and ID (accepts sub-fields "owner_id" and "owner_resource")',
                     'location'    => 'query',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'fields' => [
@@ -2728,9 +2728,9 @@ return [
             'parameters'       => [
                 'title' => [
                     'description' => 'Smart collection title',
-                    'location'    => 'query',
+                    'location'    => 'json',
                     'type'        => 'string',
-                    'required'    => false
+                    'required'    => true
                 ],
                 'body_html' => [
                     'description' => 'Collection description',
@@ -2747,7 +2747,7 @@ return [
                 'image' => [
                     'description' => 'Attached image (can accept a "src" or "attachment" sub-parameter)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'rules' => [
@@ -2799,7 +2799,7 @@ return [
                 'image' => [
                     'description' => 'Attached image (can accept a "src" or "attachment" sub-parameter)',
                     'location'    => 'json',
-                    'type'        => 'array',
+                    'type'        => 'object',
                     'required'    => false
                 ],
                 'rules' => [


### PR DESCRIPTION
This PR fixes some minor issues in the descriptor. Also, it changes some "array" type to "object" type.

Previously, parameters that looked like this:

```json
"image": {
   "src": "abc"
}
```

and

```json
"variants": [
   {
   },
   {
   }
]
```

were represented using the "array" type. Actually, the first one should be a type "object", while the second should be array.

This didn't make any difference as it was serialized the same way, but it's better to keep a more precise semantics to have better validation by the Guzzle client.