### PR TITLE
Changed root_key to NULL in CancelOrder service description to match …

### DIFF
--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -1237,7 +1237,7 @@ return [
             'uri'              => 'admin/orders/{id}/cancel.json',
             'responseModel'    => 'GenericModel',
             'summary'          => 'Cancel a given order',
-            'data'             => ['root_key' => 'order'],
+            'data'             => ['root_key' => null],
             'parameters'       => [
                 'id' => [
                     'description' => 'Order ID',


### PR DESCRIPTION
…what the Shopify API expects.

I feel this was the cleanest most simple way to fix this inconsistency.
Since Shopify's response for canceling an order contains additional information outside the 'order' parameter, I felt it's best to leave it in.

IE, the order cancel response contains "notice" along with a message of success or not.
This would be lost if we were to unwrap the response.

