### PR TITLE
Changed the additional parameters for CreateWebhook to json

### DIFF
--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -2969,7 +2969,7 @@ return [
                 ],
             ],
             'additionalParameters' => [
-                'location' => 'query',
+                'location' => 'json',
             ],
         ],
 


### PR DESCRIPTION
Having the additional parameters in the query was causing the 'fields' and 'metafield_namespaces' parameters for this request to not work.