### PR TITLE
added draft order support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.phpunit.result.cache
 ._*
 .~lock.*
 .buildpath

--- a/README.md
+++ b/README.md
@@ -565,6 +565,17 @@ Here is a list of supported endpoints (more to come in the future):
 * array openOrder(array $args = [])
 * array cancelOrder(array $args = [])
 
+**DRAFT ORDER RELATED METHODS:**
+
+* array getDraftOrders(array $args = [])
+* int getDraftOrderCount(array $args = [])
+* array createDraftOrder(array $args = [])
+* array updateDraftOrder(array $args = [])
+* array getDraftOrder(array $args = []) 
+* array sendDraftOrderInvoice(array $args = [])
+* array completeDraftOrder(array $args = [])
+* array deleteDraftOrder(array $args = [])
+
 **PAGE RELATED METHODS:**
 
 * array getPages(array $args = [])

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "zendframework/zend-diactoros": "^1.3 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2",
+        "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^2.5"
     },
     "suggest": {

--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -1787,6 +1787,142 @@ return [
 
         /**
          * --------------------------------------------------------------------------------
+         * DRAFT ORDER RELATED METHODS
+         *
+         * DOC: https://help.shopify.com/en/api/reference/orders/draftorder
+         * --------------------------------------------------------------------------------
+         */
+
+        'GetDraftOrders' => [
+            'httpMethod'           => 'GET',
+            'uri'                  => 'admin/draft_orders.json',
+            'responseModel'        => 'GenericModel',
+            'summary'              => 'Retrieve a list of draft orders',
+            'data'                 => ['root_key' => 'draft_orders'],
+            'additionalParameters' => [
+                'location' => 'query',
+            ],
+        ],
+
+        'GetDraftOrderCount' => [
+            'httpMethod'           => 'GET',
+            'uri'                  => 'admin/draft_orders/count.json',
+            'responseModel'        => 'GenericModel',
+            'summary'              => 'Retrieve the number of draft orders',
+            'additionalParameters' => [
+                'location' => 'query',
+            ],
+        ],
+
+        'GetDraftOrder' => [
+            'httpMethod'       => 'GET',
+            'uri'              => 'admin/draft_orders/{id}.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Retrieve specific draft order',
+            'data'             => ['root_key' => 'draft_order'],
+            'parameters'       => [
+                'id' => [
+                    'description' => 'Order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ],
+            'additionalParameters' => [
+                'location' => 'query',
+            ],
+        ],
+
+        'CreateDraftOrder' => [
+            'httpMethod'       => 'POST',
+            'uri'              => 'admin/draft_orders.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Create a new draft order',
+            'data'             => ['root_key' => 'draft_order'],
+            'parameters'       => [
+                'line_items' => [
+                    'description' => 'The draft order line items',
+                    'location'    => 'json',
+                    'type'        => 'array',
+                    'required'    => true
+                ],
+            ],
+            'additionalParameters' => [
+                'location' => 'json',
+            ],
+        ],
+
+        'SendDraftOrderInvoice' => [
+            'httpMethod'       => 'POST',
+            'uri'              => 'admin/draft_orders/{id}/send_invoice.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Send an invoice for the draft order',
+            'data'             => ['root_key' => 'draft_order'],
+            'parameters'       => [
+                'id' => [
+                    'description' => 'Draft order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ],
+            'additionalParameters' => [
+                'location' => 'json',
+            ],
+        ],
+
+        'UpdateDraftOrder' => [
+            'httpMethod'           => 'PUT',
+            'uri'                  => 'admin/draft_orders/{id}.json',
+            'responseModel'        => 'GenericModel',
+            'summary'              => 'Update an existing draft order',
+            'data'                 => ['root_key' => 'draft_order'],
+            'parameters'           => [
+                'id' => [
+                    'description' => 'Draft order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ],
+            'additionalParameters' => [
+                'location' => 'json',
+            ],
+        ],
+
+        'DeleteDraftOrder' => [
+            'httpMethod'       => 'DELETE',
+            'uri'              => 'admin/draft_orders/{id}.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Delete the draft order from the database',
+            'parameters'       => [
+                'id' => [
+                    'description' => 'Draft order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ]
+            ]
+        ],
+
+        'CompleteDraftOrder' => [
+            'httpMethod'       => 'PUT',
+            'uri'              => 'admin/draft_orders/{id}/complete.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Complete a draft order, marking it as paid',
+            'data'             => ['root_key' => 'draft_order'],
+            'parameters'       => [
+                'id' => [
+                    'description' => 'Order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ]
+            ]
+        ],
+
+        /**
+         * --------------------------------------------------------------------------------
          * PAGE RELATED METHODS
          *
          * DOC: https://docs.shopify.com/api/page

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -176,6 +176,17 @@ use ZfrShopify\Exception\RuntimeException;
  * @method array openOrder(array $args = []) {@command Shopify OpenOrder}
  * @method array cancelOrder(array $args = []) {@command Shopify CancelOrder}
  *
+ * DRAFT ORDER RELATED METHODS:
+ *
+ * @method array getDraftOrders(array $args = []) {@command Shopify GetDraftOrders}
+ * @method int getDraftOrderCount(array $args = []) {@command Shopify GetDraftOrderCount}
+ * @method array createDraftOrder(array $args = []) {@command Shopify CreateDraftOrder}
+ * @method array updateDraftOrder(array $args = []) {@command Shopify UpdateDraftOrder}
+ * @method array getDraftOrder(array $args = []) {@command Shopify GetDraftOrder}
+ * @method array sendDraftOrderInvoice(array $args = []) {@command Shopify SendDraftOrderInvoice}
+ * @method array completeDraftOrder(array $args = []) {@command Shopify CompleteDraftOrder}
+ * @method array deleteDraftOrder(array $args = []) {@command Shopify DeleteDraftOrder}
+ *
  * PAGE RELATED METHODS:
  *
  * @method array getPages(array $args = []) {@command Shopify GetPages}

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -19,11 +19,12 @@
 namespace ZfrShopifyTest;
 
 use ZfrShopify\ConfigProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Daniel Gimenes
  */
-final class ConfigProviderTest extends \PHPUnit\Framework\TestCase
+final class ConfigProviderTest extends TestCase
 {
     public function testProvidesContainerConfig()
     {

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -23,7 +23,7 @@ use ZfrShopify\ConfigProvider;
 /**
  * @author Daniel Gimenes
  */
-final class ConfigProviderTest extends \PHPUnit_Framework_TestCase
+final class ConfigProviderTest extends \PHPUnit\Framework\TestCase
 {
     public function testProvidesContainerConfig()
     {

--- a/test/Container/ShopifyClientFactoryTest.php
+++ b/test/Container/ShopifyClientFactoryTest.php
@@ -21,11 +21,12 @@ namespace ZfrShopifyTest\Container;
 use Psr\Container\ContainerInterface;
 use ZfrShopify\Exception\RuntimeException;
 use ZfrShopify\Container\ShopifyClientFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michaël Gallego
  */
-class ShopifyClientFactoryTest extends \PHPUnit_Framework_TestCase
+class ShopifyClientFactoryTest extends TestCase
 {
     public function testThrowExceptionIfNoConfig()
     {

--- a/test/Container/TokenExchangerFactoryTest.php
+++ b/test/Container/TokenExchangerFactoryTest.php
@@ -20,11 +20,12 @@ namespace ZfrShopifyTest\Container;
 
 use Psr\Container\ContainerInterface;
 use ZfrShopify\Container\TokenExchangerFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michaël Gallego
  */
-class TokenExchangerFactoryTest extends \PHPUnit_Framework_TestCase
+class TokenExchangerFactoryTest extends TestCase
 {
     public function testFactory()
     {

--- a/test/Model/ShopDomainTest.php
+++ b/test/Model/ShopDomainTest.php
@@ -20,8 +20,9 @@ namespace ZfrShopifyTest\Model;
 
 use ZfrShopify\Exception\InvalidArgumentException;
 use ZfrShopify\Model\ShopDomain;
+use PHPUnit\Framework\TestCase;
 
-class ShopDomainTest extends \PHPUnit_Framework_TestCase
+class ShopDomainTest extends TestCase
 {
     public function domainProvider()
     {

--- a/test/OAuth/AuthorizationRedirectResponseTest.php
+++ b/test/OAuth/AuthorizationRedirectResponseTest.php
@@ -19,11 +19,12 @@
 namespace ZfrShopifyTest\OAuth;
 
 use ZfrShopify\OAuth\AuthorizationRedirectResponse;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michaël Gallego
  */
-class AuthorizationRedirectResponseTest extends \PHPUnit_Framework_TestCase
+class AuthorizationRedirectResponseTest extends TestCase
 {
     public function shopDomainProvider()
     {

--- a/test/OAuth/TokenExchangerTest.php
+++ b/test/OAuth/TokenExchangerTest.php
@@ -22,11 +22,12 @@ use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use ZfrShopify\Exception\RuntimeException;
 use ZfrShopify\OAuth\TokenExchanger;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michaël Gallego
  */
-class TokenExchangerTest extends \PHPUnit_Framework_TestCase
+class TokenExchangerTest extends TestCase
 {
     public function shopDomainProvider()
     {

--- a/test/ShopifyClientTest.php
+++ b/test/ShopifyClientTest.php
@@ -35,7 +35,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @author Michaël Gallego
  */
-class ShopifyClientTest extends \PHPUnit\Framework\TestCase
+class ShopifyClientTest extends TestCase
 {
     public function validationData()
     {

--- a/test/ShopifyClientTest.php
+++ b/test/ShopifyClientTest.php
@@ -30,11 +30,12 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use ZfrShopify\Exception\RuntimeException;
 use ZfrShopify\ShopifyClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michaël Gallego
  */
-class ShopifyClientTest extends \PHPUnit_Framework_TestCase
+class ShopifyClientTest extends \PHPUnit\Framework\TestCase
 {
     public function validationData()
     {

--- a/test/Validator/ApplicationProxyRequestValidatorTest.php
+++ b/test/Validator/ApplicationProxyRequestValidatorTest.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use ZfrShopify\Exception\InvalidApplicationProxyRequestException;
 use ZfrShopify\Validator\ApplicationProxyRequestValidator;
 
-class ApplicationProxyRequestValidatorTest extends \PHPUnit_Framework_TestCase
+class ApplicationProxyRequestValidatorTest extends \PHPUnit\Framework\TestCase
 {
     public function testValidateSignature()
     {

--- a/test/Validator/RequestValidatorTest.php
+++ b/test/Validator/RequestValidatorTest.php
@@ -25,7 +25,7 @@ use ZfrShopify\Validator\RequestValidator;
 /**
  * @author Michaël Gallego
  */
-class RequestValidatorTest extends \PHPUnit_Framework_TestCase
+class RequestValidatorTest extends \PHPUnit\Framework\TestCase
 {
     public function shopHmacProvider()
     {

--- a/test/Validator/WebhookValidatorTest.php
+++ b/test/Validator/WebhookValidatorTest.php
@@ -25,7 +25,7 @@ use ZfrShopify\Validator\WebhookValidator;
 /**
  * @author Michaël Gallego
  */
-class WebhookValidatorTest extends \PHPUnit_Framework_TestCase
+class WebhookValidatorTest extends \PHPUnit\Framework\TestCase
 {
     public function testThrowExceptionIfWebhookHeaderIsNotPresent()
     {


### PR DESCRIPTION
Hi,

I've extended this library to support the Shopify Draft Order API. 
Additionally, I've changed the PHPUnit "extend" formula to be compatible with 8.0.2 version.

I checked the draft order actions on my dev Shopify account and It's working. Please review my additions.

Cheers,
Mateusz