### PR TITLE
Fixed incorrect root_key when creating a script tag

### DIFF
--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -3156,7 +3156,7 @@ return [
             'uri'              => 'admin/script_tags.json',
             'responseModel'    => 'GenericModel',
             'summary'          => 'Create a new script tags',
-            'data'             => ['root_key' => 'script_tags'],
+            'data'             => ['root_key' => 'script_tag'],
             'parameters'       => [
                 'event' => [
                     'description' => 'Event value when the script tag is loaded',


### PR DESCRIPTION
See https://help.shopify.com/en/api/reference/online-store/scripttag#create