### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -1849,7 +1849,7 @@ return [
               'description' => 'Order ID',
               'location'    => 'uri',
               'type'        => 'integer',
-              'required'    => TRUE
+              'required'    => true
             ],
           ],
           'additionalParameters' => [


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!