### PR TITLE
Add support for the link based pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.0.0
+
+* If you are using the 2020-01 API or newer for the REST API, it will now uses the link based pagination when the
+iterator methods are used.
+
 # 5.3.0
 
 * Add collect endpoints

--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -5072,7 +5072,14 @@ return [
 
     'models' => [
         'GenericModel' => [
-            'type'                 => 'object',
+            'type'       => 'object',
+            'properties' => [
+                'pagination' => [
+                    'location' => 'header',
+                    'sentAs'   => 'Link',
+                    'type'     => 'string'
+                ]
+            ],
             'additionalProperties' => [
                 'location' => 'json'
             ]

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -602,12 +602,7 @@ class ShopifyClient
         // When using the iterator, we force the maximum number of items per page. Also, if no "since_id" is set, we force it to 0 because by
         // default Shopify sort resources by title
         $args['limit'] = 250;
-
-        if ($commandName === 'getGiftCards') {
-            $args['page'] = $args['page'] ?? 1;
-        } else {
-            $args['since_id'] = $args['since_id'] ?? 0;
-        }
+        $args['since_id'] = $args['since_id'] ?? 0;
 
         // Because the iteration depends on the presence of the "id" field, we must make sure that if the "fields" filter is set, it contains
         // at the minimum the "id" one. We make a simple detection here
@@ -624,14 +619,8 @@ class ShopifyClient
                 yield $result;
             }
 
-            // Unfortunately as of today gift card endpoint does not support "since_id" parameter, so we are forced to use the page
-            // instead of this endpoint
-            if ($commandName === 'getGiftCards') {
-                $args['page']++;
-            } else {
-                // Advance the since_id
-                $args['since_id'] = end($results)['id'];
-            }
+            // Advance the since_id
+            $args['since_id'] = end($results)['id'];
         } while(count($results) >= 250);
     }
 

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -401,27 +401,11 @@ class ShopifyClient
      */
     public function getCommand(string $method, $args = []): CommandInterface
     {
-        // Add the mandatory version
-
-        $args = array_merge($args, ['version' => $this->connectionOptions['version']]);
-
-        // Add authentication parameters to each command based on the Shopify app type
-
-        if ($this->connectionOptions['private_app']) {
-            $args = array_merge($args, [
-                '@http' => [
-                    'auth' => [$this->connectionOptions['api_key'], $this->connectionOptions['password']]
-                ]
-            ]);
-        } else {
-            $args = array_merge($args, [
-                '@http' => [
-                    'headers' => [
-                        'X-Shopify-Access-Token' => $this->connectionOptions['access_token']
-                    ]
-                ]
-            ]);
-        }
+        $args = array_merge(
+            $args,
+            ['version' => $this->connectionOptions['version']],
+            ['@http' => $this->getRequestAuthorizationArguments()]
+        );
 
         return $this->guzzleClient->getCommand(ucfirst($method), $args);
     }
@@ -436,7 +420,7 @@ class ShopifyClient
     {
         $result = $this->guzzleClient->execute($command);
 
-        return $this->unwrapResponseData($command, $result);
+        return $this->unwrapResponseData($command, $result->toArray());
     }
 
     /**
@@ -455,7 +439,7 @@ class ShopifyClient
         /** @var Result $commandResult */
         foreach ($commandResults as $index => $commandResult) {
             // If the command has failed, we store the exception, otherwise the payload
-            $results[$index] = ($commandResult instanceof CommandException) ? $commandResult : $this->unwrapResponseData($commands[$index], $commandResult);
+            $results[$index] = ($commandResult instanceof CommandException) ? $commandResult : $this->unwrapResponseData($commands[$index], $commandResult->toArray());
         }
 
         return $results;
@@ -599,29 +583,71 @@ class ShopifyClient
      */
     private function iterateResources(string $commandName, array $args): Generator
     {
-        // When using the iterator, we force the maximum number of items per page. Also, if no "since_id" is set, we force it to 0 because by
-        // default Shopify sort resources by title
-        $args['limit'] = 250;
-        $args['since_id'] = $args['since_id'] ?? 0;
+        // Since the 2020-01 version, Shopify now uses a cursor based approach
+        if ($this->connectionOptions['version'] >= '2020-01') {
+            // We force a limit of 250 to limit the number of needed requests
+            $args['limit'] = 250;
 
-        // Because the iteration depends on the presence of the "id" field, we must make sure that if the "fields" filter is set, it contains
-        // at the minimum the "id" one. We make a simple detection here
-        if (isset($args['fields'])) {
-            $fields         = explode(',', str_replace(' ', '', $args['fields']));
-            $args['fields'] = implode(',', array_unique(array_merge(['id'], $fields)));
-        }
-
-        do {
+            // Do the first request to initate the process
             $command = $this->getCommand($commandName, $args);
-            $results = $this->execute($command);
+            $results = $this->guzzleClient->execute($command);
 
-            foreach ($results as $result) {
-                yield $result;
+            // For the data itself, we delegate to unwrap response data
+            $resources = $this->unwrapResponseData($command, $results->toArray());
+
+            foreach ($resources as $resource) {
+                yield $resource;
             }
 
-            // Advance the since_id
-            $args['since_id'] = end($results)['id'];
-        } while(count($results) >= 250);
+            // To continue the iteration, we have to use the pagination link (if present)
+            $linkHeader = $results['pagination'] ?? '';
+
+            while (!empty($linkHeader)) {
+                preg_match("/<(.*)>; rel=\"next\"/", $linkHeader, $matches);
+
+                if (!isset($matches[1])) {
+                    break;
+                }
+
+                // We initiate the next request using the bare client, as we can't re-use commands at this stage
+                $httpClient = $this->guzzleClient->getHttpClient();
+                $response   = $httpClient->request('GET', $matches[1], $this->getRequestAuthorizationArguments());
+
+                // Decode the response and yield the result
+                $resources = $this->unwrapResponseData($command, json_decode($response->getBody()->getContents(), true));
+
+                foreach ($resources as $resource) {
+                    yield $resource;
+                }
+
+                // Extract the header line (if any) to continue the process
+                $linkHeader = $response->getHeaderLine('Link');
+            }
+        } else {
+            // When using the iterator, we force the maximum number of items per page. Also, if no "since_id" is set, we force it to 0 because by
+            // default Shopify sort resources by title
+            $args['limit'] = 250;
+            $args['since_id'] = $args['since_id'] ?? 0;
+
+            // Because the iteration depends on the presence of the "id" field, we must make sure that if the "fields" filter is set, it contains
+            // at the minimum the "id" one. We make a simple detection here
+            if (isset($args['fields'])) {
+                $fields         = explode(',', str_replace(' ', '', $args['fields']));
+                $args['fields'] = implode(',', array_unique(array_merge(['id'], $fields)));
+            }
+
+            do {
+                $command = $this->getCommand($commandName, $args);
+                $results = $this->execute($command);
+
+                foreach ($results as $result) {
+                    yield $result;
+                }
+
+                // Advance the since_id
+                $args['since_id'] = end($results)['id'];
+            } while(count($results) >= 250);
+        }
     }
 
     /**
@@ -629,38 +655,36 @@ class ShopifyClient
      * the data by the "shop" key. This is a bit inconvenient to use in userland. As a consequence, we always "unwrap" the result.
      *
      * @param  CommandInterface $command
-     * @param  ToArrayInterface $commandResult
+     * @param  array            $bodyPayload
      * @return mixed
      */
-    private function unwrapResponseData(CommandInterface $command, ToArrayInterface $commandResult)
+    private function unwrapResponseData(CommandInterface $command, array $bodyPayload)
     {
         $operation = $this->guzzleClient->getDescription()->getOperation($command->getName());
         $rootKey   = $operation->getData('root_key');
-
-        $arrayResult = $commandResult->toArray();
-        $result      = (null === $rootKey) ? $arrayResult : $arrayResult[$rootKey];
+        $result    = (null === $rootKey) ? $bodyPayload : $bodyPayload[$rootKey];
 
         if (substr($command->getName(), -5) === 'Count') {
             return $result['count'];
         }
 
-        // If there is a pagination element, we add it to a specific "pagination" hash
-        if (isset($arrayResult['pagination'])) {
-            $pagination = [];
-
-            preg_match("/<(.*)>; rel=\"next\"/", $arrayResult['pagination'], $matches);
-            if (isset($matches[1])) {
-                $pagination['pagination']['next'] = $matches[1];
-            }
-
-            preg_match("/<(.*)>; rel=\"prev\"/", $arrayResult['pagination'], $matches);
-            if (isset($matches[1])) {
-                $pagination['pagination']['prev'] = $matches[1];
-            }
-
-            $result = array_merge($result, $pagination);
-        }
-
         return $result;
+    }
+
+    private function getRequestAuthorizationArguments(): array
+    {
+        // Add authentication parameters to each command based on the Shopify app type
+
+        if ($this->connectionOptions['private_app']) {
+            return [
+                'auth' => [$this->connectionOptions['api_key'], $this->connectionOptions['password']]
+            ];
+        } else {
+            return [
+                'headers' => [
+                    'X-Shopify-Access-Token' => $this->connectionOptions['access_token']
+                ]
+            ];
+        }
     }
 }


### PR DESCRIPTION
If you are using the 2020-01 API or sooner, the library will now use the URL set up in the "Link" header to perform the pagination. The implementation is not optimal (quite a lot of redundant code) but it should work!