### PR TITLE
Allow passing addl. Guzzle middleware in to GuzzleClient in createDefaultClient().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Extend ShopifyClient to allow passing in array of middleware to be added to GuzzleClient handler stack.
 
+# 6.2.0
+
+* Add metafields methods for blog, collection, draft order resources
+
 # 6.1.0
 
 * Upgrade dependencies to use "Laminas" instead of deprecated Zend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.2.1
+
+* Extend ShopifyClient to allow passing in array of middleware to be added to GuzzleClient handler stack.
+
 # 6.1.0
 
 * Upgrade dependencies to use "Laminas" instead of deprecated Zend

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -575,8 +575,7 @@ class ShopifyClient
         $handlerStack = HandlerStack::create(new CurlHandler());
         $handlerStack->push(Middleware::retry([$this, 'retryDecider'], [$this, 'retryDelay']));
 
-        foreach ($guzzleMiddleware as $curMiddleware)
-        {
+        foreach ($guzzleMiddleware as $curMiddleware) {
             $handlerStack->push($curMiddleware);
         }
 
@@ -656,7 +655,7 @@ class ShopifyClient
 
                 // Advance the since_id
                 $args['since_id'] = end($results)['id'];
-            } while(count($results) >= 250);
+            } while (count($results) >= 250);
         }
     }
 


### PR DESCRIPTION
Extend ShopifyClient to allow passing in array of middleware to be added to GuzzleClient handler stack.

This is preferable to passing in an entire GuzzleClient. The reason is because when you pass in a GuzzleClient from outside, you lose all the logic in the retry middleware. You also lose all the logic in the wrapRequestData Command-to-request transformer.