### PR TITLE
Added check before iterating over GraphQL result

### DIFF
--- a/src/ShopifyGraphQLClient.php
+++ b/src/ShopifyGraphQLClient.php
@@ -121,10 +121,12 @@ class ShopifyGraphQLClient
 
         // We also check for "userErrors" (this requires that they are part of the request though) to throw a
         // specific exception
-
-        foreach (current($result['data']) as $key => $value) {
-            if ($key === 'userErrors' && !empty($value)) {
-                throw new GraphQLUserErrorException($value);
+        
+        if(is_iterable(current($result['data']))) {
+            foreach (current($result['data']) as $key => $value) {
+                if ($key === 'userErrors' && !empty($value)) {
+                    throw new GraphQLUserErrorException($value);
+                }
             }
         }
 

--- a/src/ShopifyGraphQLClient.php
+++ b/src/ShopifyGraphQLClient.php
@@ -121,8 +121,8 @@ class ShopifyGraphQLClient
 
         // We also check for "userErrors" (this requires that they are part of the request though) to throw a
         // specific exception
-        
-        if(is_iterable(current($result['data']))) {
+
+        if (is_iterable(current($result['data']))) {
             foreach (current($result['data']) as $key => $value) {
                 if ($key === 'userErrors' && !empty($value)) {
                     throw new GraphQLUserErrorException($value);


### PR DESCRIPTION
This is needed because when an object does not exist Shopify returns a null result. Since it cannot be iterated a 500 error is being thrown.

For example the following query:

{
  product(id: "gid://shopify/Product/123") {
    id
  }
}

Will return:

{
  "data": {
    "product": null
  },
  "extensions": {
    "cost": {
      "requestedQueryCost": 1,
      "actualQueryCost": 1,
      "throttleStatus": {
        "maximumAvailable": 1000,
        "currentlyAvailable": 999,
        "restoreRate": 50
      }
    }
  }
}