### PR TITLE
Include dependency symfony/psr-http-message-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "guzzlehttp/guzzle-services": "^1.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
+        "symfony/psr-http-message-bridge": "^2.0",
         "laminas/laminas-diactoros": "^1.3 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is a requirement of this package, and isn't a dependency of any of the existing dependencies so should probably be included as a dependency.