### PR TITLE
Add fulfillment order endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 6.6.0
+
+* Added fulfillment order endpoints
+
+# 6.5.1
+
+* Fixed storefront access token method
+
+# 6.5.0
+
+* Add storefront access tokens related methods
+
+# 6.4.0
+
+* Add support for shipping zones in the REST API
+
+# 6.3.1
+
+* Add check before iterating GraphQL results
+
 # 6.3.0
 
 * Add customer address endpoints

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $shopifyClient = new ShopifyClient([
 ### Public app
 
 When using a public app, you instantiate the client a bit differently:
- 
+
 ```php
 $shopifyClient = new ShopifyClient([
     'private_app'   => false,
@@ -137,7 +137,7 @@ try {
 
 ### Create an authorization response
 
-ZfrShopify provides an easy way to create a PSR7 compliant `ResponseInterface` to create an authorization response: 
+ZfrShopify provides an easy way to create a PSR7 compliant `ResponseInterface` to create an authorization response:
 
 ```php
 use ZfrShopify\OAuth\AuthorizationRedirectResponse;
@@ -257,7 +257,7 @@ foreach ($results as $singleResult) {
       $command = $singleResult->getCommand();
       continue;
    }
-   
+
    // Otherwise, $singleResult is just an array that contains the Shopify data
 }
 ```
@@ -372,7 +372,7 @@ $variables = [
 $result = $client->request($request, $variables);
 
 var_dump($result);
-``` 
+```
 
 ### Mutations
 
@@ -428,7 +428,7 @@ try {
 
 #### User errors
 
-Those errors are for requests that are missing data (like incorrect data, missing data...). You can catch them using the 
+Those errors are for requests that are missing data (like incorrect data, missing data...). You can catch them using the
 `\ZfrShopify\Exception\GraphQLUserErrorException` exception:
 
 ```php
@@ -560,7 +560,17 @@ Here is a list of supported endpoints (more to come in the future):
 * array createFulfillment(array $args = [])
 * array updateFilfillment(array $args = [])
 * array completeFulfillment(array $args = [])
-* array cancelFulfillment(array $args = []) 
+* array cancelFulfillment(array $args = [])
+
+**FULFILLMENT ORDER RELATED METHODS:**
+
+* array getFulfillmentOrders(array $args = [])
+* array getFulfillmentOrder(array $args = [])
+* array cancelFulfillmentOrder(array $args = [])
+* array closeFulfillmentOrder(array $args = [])
+* array moveFulfillmentOrder(array $args = [])
+* array openFulfillmentOrder(array $args = [])
+* array rescheduleFulfillmentOrder(array $args = [])
 
 **GIFT CARD RELATED METHODS:**
 
@@ -619,7 +629,7 @@ Here is a list of supported endpoints (more to come in the future):
 * int getDraftOrderCount(array $args = [])
 * array createDraftOrder(array $args = [])
 * array updateDraftOrder(array $args = [])
-* array getDraftOrder(array $args = []) 
+* array getDraftOrder(array $args = [])
 * array sendDraftOrderInvoice(array $args = [])
 * array completeDraftOrder(array $args = [])
 * array deleteDraftOrder(array $args = [])

--- a/src/ServiceDescription/Shopify-v1.php
+++ b/src/ServiceDescription/Shopify-v1.php
@@ -2257,6 +2257,174 @@ return [
 
         /**
          * --------------------------------------------------------------------------------
+         * FULFILLMENT ORDER RELATED METHODS
+         *
+         * DOC: https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillmentorder
+         * --------------------------------------------------------------------------------
+         */
+
+        'GetFulfillmentOrders' => [
+            'httpMethod'       => 'GET',
+            'uri'              => 'admin/api/{version}/orders/{order_id}/fulfillment_orders.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Retrieves a list of fulfillment orders for a specific order',
+            'data'             => ['root_key' => 'fulfillment_orders'],
+            'parameters'       => [
+                'version' => [
+                    'description' => 'API version',
+                    'location'    => 'uri',
+                    'type'        => 'string',
+                    'required'    => true
+                ],
+                'order_id' => [
+                    'description' => 'The ID of the order that is associated with the fulfillment orders',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ],
+            'additionalParameters' => [
+                'location' => 'query',
+            ],
+        ],
+
+        'GetFulfillmentOrder' => [
+            'httpMethod'       => 'GET',
+            'uri'              => 'admin/api/{version}/fulfillment_orders/{fulfillment_order_id}.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Retrieves a specific fulfillment order',
+            'data'             => ['root_key' => 'fulfillment_order'],
+            'parameters'       => [
+                'version' => [
+                    'description' => 'API version',
+                    'location'    => 'uri',
+                    'type'        => 'string',
+                    'required'    => true
+                ],
+                'fulfillment_order_id' => [
+                    'description' => 'The ID of the fulfillment order to retrieve',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ],
+            'additionalParameters' => [
+                'location' => 'query',
+            ],
+        ],
+
+        'CancelFulfillmentOrder' => [
+            'httpMethod'       => 'POST',
+            'uri'              => 'admin/api/{version}/fulfillment_orders/{fulfillment_order_id}/cancel.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Marks a fulfillment order as cancelled',
+            'data'             => ['root_key' => 'fulfillment_order'],
+            'parameters'       => [
+                'version' => [
+                    'description' => 'API version',
+                    'location'    => 'uri',
+                    'type'        => 'string',
+                    'required'    => true
+                ],
+                'fulfillment_order_id' => [
+                    'description' => 'Fulfillment Order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ]
+        ],
+
+        'CloseFulfillmentOrder' => [
+            'httpMethod'       => 'POST',
+            'uri'              => 'admin/api/{version}/fulfillment_orders/{fulfillment_order_id}/close.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Marks an in progress fulfillment order as incomplete, indicating the fulfillment service is unable to ship any remaining items and intends to close the fulfillment order',
+            'data'             => ['root_key' => 'fulfillment_order'],
+            'parameters'       => [
+                'version' => [
+                    'description' => 'API version',
+                    'location'    => 'uri',
+                    'type'        => 'string',
+                    'required'    => true
+                ],
+                'fulfillment_order_id' => [
+                    'description' => 'Fulfillment Order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ]
+        ],
+
+        'MoveFulfillmentOrder' => [
+            'httpMethod'       => 'POST',
+            'uri'              => 'admin/api/{version}/fulfillment_orders/{fulfillment_order_id}/move.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Moves a fulfillment order from one merchant managed location to another merchant managed location',
+            'data'             => ['root_key' => 'fulfillment_order'],
+            'parameters'       => [
+                'version' => [
+                    'description' => 'API version',
+                    'location'    => 'uri',
+                    'type'        => 'string',
+                    'required'    => true
+                ],
+                'fulfillment_order_id' => [
+                    'description' => 'Fulfillment Order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ]
+        ],
+
+        'OpenFulfillmentOrder' => [
+            'httpMethod'       => 'POST',
+            'uri'              => 'admin/api/{version}/fulfillment_orders/{fulfillment_order_id}/open.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Marks a scheduled fulfillment order as ready for fulfillment',
+            'data'             => ['root_key' => 'fulfillment_order'],
+            'parameters'       => [
+                'version' => [
+                    'description' => 'API version',
+                    'location'    => 'uri',
+                    'type'        => 'string',
+                    'required'    => true
+                ],
+                'fulfillment_order_id' => [
+                    'description' => 'Fulfillment Order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ]
+        ],
+
+        'RescheduleFulfillmentOrder' => [
+            'httpMethod'       => 'POST',
+            'uri'              => 'admin/api/{version}/fulfillment_orders/{fulfillment_order_id}/move.json',
+            'responseModel'    => 'GenericModel',
+            'summary'          => 'Updates the fulfill_at time of a scheduled fulfillment order',
+            'data'             => ['root_key' => 'fulfillment_order'],
+            'parameters'       => [
+                'version' => [
+                    'description' => 'API version',
+                    'location'    => 'uri',
+                    'type'        => 'string',
+                    'required'    => true
+                ],
+                'fulfillment_order_id' => [
+                    'description' => 'Fulfillment Order ID',
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'required'    => true
+                ],
+            ]
+        ],
+
+        /**
+         * --------------------------------------------------------------------------------
          * GIFT CARD RELATED METHODS
          *
          * DOC: https://docs.shopify.com/api/reference/gift_card

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -30,6 +30,7 @@ use GuzzleHttp\Command\ToArrayInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -529,7 +530,7 @@ class ShopifyClient
      * @param  RequestException|null  $exception
      * @return bool
      */
-    public function retryDecider(int $retries, RequestInterface $request, ResponseInterface $response = null, $exception = null): bool
+    public function retryDecider(int $retries, RequestInterface $request, ResponseInterface $response = null, TransferException $exception = null): bool
     {
         // Limit the number of retries to 5
         if ($retries >= 5) {

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -529,7 +529,7 @@ class ShopifyClient
      * @param  RequestException|null  $exception
      * @return bool
      */
-    public function retryDecider(int $retries, RequestInterface $request, ResponseInterface $response = null, RequestException $exception = null): bool
+    public function retryDecider(int $retries, RequestInterface $request, ResponseInterface $response = null, $exception = null): bool
     {
         // Limit the number of retries to 5
         if ($retries >= 5) {

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -19,25 +19,25 @@
 namespace ZfrShopify;
 
 use Generator;
-use GuzzleHttp\Client;
-use GuzzleHttp\Command\CommandInterface;
-use GuzzleHttp\Command\Exception\CommandException;
-use GuzzleHttp\Command\Guzzle\Description;
-use GuzzleHttp\Command\Guzzle\GuzzleClient;
-use GuzzleHttp\Command\Guzzle\Serializer;
-use GuzzleHttp\Command\Result;
-use GuzzleHttp\Command\ToArrayInterface;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ServerException;
-use GuzzleHttp\Exception\TransferException;
-use GuzzleHttp\Handler\CurlHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Client;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Command\Result;
+use GuzzleHttp\Handler\CurlHandler;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\ToArrayInterface;
+use GuzzleHttp\Command\Guzzle\Serializer;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Command\Guzzle\Description;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use ZfrShopify\Exception\RuntimeException;
+use GuzzleHttp\Command\Guzzle\GuzzleClient;;
+use GuzzleHttp\Command\Exception\CommandException;
+use Psr\Http\Client\ClientExceptionInterface;
 
 /**
  * Shopify client used to interact with the Shopify API
@@ -530,7 +530,7 @@ class ShopifyClient
      * @param  RequestException|null  $exception
      * @return bool
      */
-    public function retryDecider(int $retries, RequestInterface $request, ResponseInterface $response = null, TransferException $exception = null): bool
+    public function retryDecider(int $retries, RequestInterface $request, ResponseInterface $response = null, ClientExceptionInterface $exception = null): bool
     {
         // Limit the number of retries to 5
         if ($retries >= 5) {


### PR DESCRIPTION
This change will allow access to Fulfillment Order endpoints that were recently added to Shopify.

https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillmentorder#show-2021-04