### PR TITLE
Add compatibility with php8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         }
     ],
     "require": {
-        "php": "~7.0",
+        "php": "~7.0 || ~8.0",
         "guzzlehttp/guzzle-services": "^1.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
         "laminas/laminas-diactoros": "^1.3 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^2.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "laminas/laminas-diactoros": "^1.3 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^2.5"
     },
     "suggest": {

--- a/src/Container/ShopifyGraphQLClientFactory.php
+++ b/src/Container/ShopifyGraphQLClientFactory.php
@@ -46,7 +46,7 @@ class ShopifyGraphQLClientFactory
 {
     /**
      * @param  ContainerInterface $container
-     * @return ShopifyClient
+     * @return ShopifyGraphQLClient
      */
     public function __invoke(ContainerInterface $container): ShopifyGraphQLClient
     {

--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -35,7 +35,7 @@ use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use ZfrShopify\Exception\RuntimeException;
-use GuzzleHttp\Command\Guzzle\GuzzleClient;;
+use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Exception\CommandException;
 use Psr\Http\Client\ClientExceptionInterface;
 

--- a/src/Validator/ApplicationProxyRequestValidator.php
+++ b/src/Validator/ApplicationProxyRequestValidator.php
@@ -89,7 +89,7 @@ class ApplicationProxyRequestValidator
 
         if (hash_equals($expectedSignature, hash_hmac('sha256', $signature, $sharedSecret))) {
             return;
-        };
+        }
 
         throw new Exception\InvalidApplicationProxyRequestException(
             'Incoming application proxy request from Shopify could not be validated'

--- a/src/Validator/RequestValidator.php
+++ b/src/Validator/RequestValidator.php
@@ -91,7 +91,7 @@ class RequestValidator
 
         if (hash_equals($expectedHmac, hash_hmac('sha256', $key, $sharedSecret))) {
             return;
-        };
+        }
 
         throw new Exception\InvalidRequestException('Incoming request from Shopify could not be validated');
     }

--- a/test/OAuth/AuthorizationRedirectResponseTest.php
+++ b/test/OAuth/AuthorizationRedirectResponseTest.php
@@ -44,10 +44,11 @@ class AuthorizationRedirectResponseTest extends TestCase
         $location = $response->getHeaderLine('Location');
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertStringContainsString('https://mystore.myshopify.com/admin/oauth/authorize', $location);
-        $this->assertStringContainsString('client_id=app_123', $location);
-        $this->assertStringContainsString('scope=read_content,write_content', $location);
-        $this->assertStringContainsString('redirect_uri=https://www.mysite.com', $location);
-        $this->assertStringContainsString('state=', $location);
+
+        $this->assertContains('https://mystore.myshopify.com/admin/oauth/authorize', $location);
+        $this->assertContains('client_id=app_123', $location);
+        $this->assertContains('scope=read_content,write_content', $location);
+        $this->assertContains('redirect_uri=https://www.mysite.com', $location);
+        $this->assertContains('state=', $location);
     }
 }

--- a/test/OAuth/AuthorizationRedirectResponseTest.php
+++ b/test/OAuth/AuthorizationRedirectResponseTest.php
@@ -44,10 +44,10 @@ class AuthorizationRedirectResponseTest extends TestCase
         $location = $response->getHeaderLine('Location');
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertContains('https://mystore.myshopify.com/admin/oauth/authorize', $location);
-        $this->assertContains('client_id=app_123', $location);
-        $this->assertContains('scope=read_content,write_content', $location);
-        $this->assertContains('redirect_uri=https://www.mysite.com', $location);
-        $this->assertContains('state=', $location);
+        $this->assertStringContainsString('https://mystore.myshopify.com/admin/oauth/authorize', $location);
+        $this->assertStringContainsString('client_id=app_123', $location);
+        $this->assertStringContainsString('scope=read_content,write_content', $location);
+        $this->assertStringContainsString('redirect_uri=https://www.mysite.com', $location);
+        $this->assertStringContainsString('state=', $location);
     }
 }


### PR DESCRIPTION
### Changes
- Allow to use the library with php8.0 / php8.1 executable
- allow to install PHPUnit until v8. Note that 2 warnings are emitted in v8: `Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.`
- Few syntax fixes