### PR TITLE
Remove usage of Guzzle Psr7 deprecated functions

### DIFF
--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -514,7 +514,7 @@ class ShopifyClient
 
         if (($method === 'post' || $method === 'put') && $rootKey !== null) {
             $newBody = [$rootKey => json_decode($request->getBody()->getContents(), true)];
-            $request = $request->withBody(Psr7\stream_for(json_encode($newBody)));
+            $request = $request->withBody(Psr7\Utils::streamFor(json_encode($newBody)));
         }
 
         return $request;


### PR DESCRIPTION
ShopifyClient fails when guzzlehttp/psr7 version 2.0, 2.1, 2.2, 2.3, or 2.4 is installed 
Function stream_for is deprecated and removed from guzzlehttp/psr7:2.0.
Used Utils::streamFor instead.
