### PR TITLE
psr/message bumped up to version 2.0 for later PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.0|^8.0|^8.1",
         "guzzlehttp/guzzle-services": "^1.0",
         "psr/container": "^1.0 || ^2.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "laminas/laminas-diactoros": "^1.3 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
When tried to install this package in the Laravel framework, the composer throws the following error. To fix the error package's new version is used.

 Problem 1
    - zfr/zfr-shopify 6.8.0 requires psr/container ^1.0 -> found psr/container[1.0.0, 1.1.0, 1.1.1, 1.1.2] but the package is fixed to 2.0.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - zfr/zfr-shopify 6.8.1 requires psr/http-message ^1.0 -> found psr/http-message[1.0, 1.0.1, 1.1] but the package is fixed to 2.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command. - Root composer.json requires zfr/zfr-shopify ^6.8 -> satisfiable by zfr/zfr-shopify[6.8.0, 6.8.1].