### PR TITLE
Bump laminas/laminas-diactoros version support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle-services": "^1.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "laminas/laminas-diactoros": "^1.3 || ^2.0"
+        "laminas/laminas-diactoros": "^1.3 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
This fixes the dependency issue when using this in a Laravel 12 project.